### PR TITLE
fix(boson_sampling_utilities): Lexicographic order

### DIFF
--- a/src/boson_sampling_utilities/boson_sampling_utilities.py
+++ b/src/boson_sampling_utilities/boson_sampling_utilities.py
@@ -86,7 +86,10 @@ def generate_possible_n_particle_outputs(number_of_particles: int, number_of_mod
 
         outputs.append(output)
 
-    return outputs
+    sorted_outputs = sorted([tuple(output) for output in outputs])
+
+    return [array(output) for output in sorted_outputs]
+
 
 
 def generate_lossy_inputs(initial_state: ndarray, number_of_particles_left: int) -> List[ndarray]:

--- a/src_tests/test_exact_distribution_calculator.py
+++ b/src_tests/test_exact_distribution_calculator.py
@@ -2,7 +2,7 @@ __author__ = "Tomasz Rybotycki"
 
 import unittest
 
-from numpy import array, complex128, int64
+from numpy import array, complex128, int64, allclose
 
 from src_tests import (BSPermanentCalculatorFactory, PermanentCalculatorType, BosonSamplingExperimentConfiguration,
                        BSDistributionCalculatorWithUniformLosses, BSDistributionCalculatorWithFixedLosses)
@@ -55,3 +55,21 @@ class TestExactLossyBosonSamplingDistributionCalculator(unittest.TestCase):
                                                       self._permanent_calculator)
         exact_distribution = exact_distribution_calculator.calculate_distribution()
         self.assertAlmostEqual(sum(exact_distribution), 1.0, delta=1e-4)
+
+    def test_probabilities(self) -> None:
+        exact_distribution_calculator = \
+            BSDistributionCalculatorWithUniformLosses(self.experiment_configuration,
+                                                      self._permanent_calculator)
+        exact_distribution = exact_distribution_calculator.calculate_distribution()
+        self.assertTrue(
+            allclose(
+                exact_distribution,
+                [
+                    0.008, 0.032, 0.0, 0.0, 0.032, 0.032, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                    0.128, 0.0, 0.0, 0.0, 0.128, 0.0, 0.0, 0.128, 0.0, 0.0, 0.0, 0.0,
+                    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.512, 0.0, 0.0,
+                    0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                ],
+            )
+        )


### PR DESCRIPTION
**Problem**

The Fock basis states were not ordered. In the calculations the ordering
does not matter provided that the same ordering is used everywhere, but
`BSDistributionCalculatorWithFixedLosses.calculate_distribution()`
exposes this ordering. This order has to be fixed.

**Solution**

It would be sensible to perform the ordering firstly by the number of
particles. Among the Fock states corresponding to the same number of
particles, the order could be lexicographic, i.e. for 2 modes and up to
3 particles one would get
```
00, 01, 10, 02, 11, 20, 03, 12, 21, 30.
```

Ordering by the number of particles is already present in the code.

The `generate_possible_n_particle_outputs` produces all the possible
Fock states corresponding to a fixed number of particles, but the result
was not sorted.

To lexicographically sort Fock states, one could use `numpy.lexsort`,
but its usage is quite hairy: it would require to concatenate all the
Fock states together to sort them. Instead, the Fock states got
converted into tuple, which could be sorted easily.

A test case has been written to test the value of the exact
distribution.