### PR TITLE
fix(boson_sampling_utilities): Sign error

### DIFF
--- a/src/boson_sampling_utilities/boson_sampling_utilities.py
+++ b/src/boson_sampling_utilities/boson_sampling_utilities.py
@@ -194,7 +194,7 @@ def prepare_interferometer_matrix_in_expanded_space(
     singular_values_matrix_expansion = _calculate_singular_values_matrix_expansion(
         singular_values)
     singular_values_expanded_matrix = block(
-        [[diag(singular_values), singular_values_matrix_expansion],
+        [[diag(singular_values), -singular_values_matrix_expansion],
          [singular_values_matrix_expansion, diag(singular_values)]])
     return expanded_v @ singular_values_expanded_matrix @ expanded_u
 


### PR DESCRIPTION
The `prepare_interferometer_matrix_in_expanded_space`
should expand the input interferometer matrix - which is not necessarily
a unitary matrix due to the loss - to a unitary matrix.

Furthermore, the `singular_values_expanded_matrix` needs to be an
orthogonal matrix in order for the product
```
expanded_v @ singular_values_expanded_matrix @ expanded_u
```
to be unitary. However, the `singular_values_matrix_expansion` is
generally not orthogonal in the current implementation, possibly due to
a missing sign in an offdiagonal block. This issue has been fixed in
this patch.

**Note**:

When simulating lossy boson sampling, the initial state is expanded with
zeros. In this scenario, the devised fix doesn't make any difference,
but it might be good to fix this typo to avoid later (possible) issues.