### PR TITLE
fix: Making R optional

### DIFF
--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -1,0 +1,2 @@
+# Optional requirements (optionally ignored during tests)
+rpy2>=3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,3 @@ r = [
 
 [project.urls]
 Home = "https://github.com/Tomev-CTP/BoSS"
-
-[tool.pytest.ini_options]
-markers = [
-    "ignore: marks ignored tests (deselect with '-m \"not ignore\"')",
-]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,6 @@
 numpy>=1.19
 scipy>=1.5
 guancodes~=0.0.3
-# Optional (and ignored during tests)
-rpy2>=3.0
 # Testing
 pytest>=7.0.1
 tqdm>=4.0

--- a/tests/test_ccr_simulation_strategy.py
+++ b/tests/test_ccr_simulation_strategy.py
@@ -5,6 +5,8 @@ __author__ = "Tomasz Rybotycki"
     basically just test of a wrapper of their R implementation.
 """
 
+import sys
+
 import pytest
 
 from tests.simulation_strategies_tests_common import (
@@ -13,23 +15,23 @@ from tests.simulation_strategies_tests_common import (
     StrategyType
 )
 
+try:
+    import rpy2
+except ImportError:
+    pass
+
 
 class TestCCRSimulationStrategy(TestBSClassicalSimulationStrategies):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    @pytest.mark.ignore
+    @pytest.mark.skipif("rpy2" not in sys.modules, reason="The package 'rpy2' is not installed.")
     def test_haar_random_interferometers_distance_for_ccr_strategy(self) -> None:
         self._set_experiment_configuration_for_lossless_haar_random()
-        try:
-            strategy_factory = SimulationStrategyFactory(
-                self._haar_random_experiment_configuration,
-                self._bs_permanent_calculator,
-                StrategyType.CLIFFORD_R)
-            self._test_state_average_probability_for_haar_random_matrices(
-                strategy_factory)
-        except Exception as e:
-            print("You don't have packages required for this strategy.")
-            print(e)
-            self.assertTrue(True)
+        strategy_factory = SimulationStrategyFactory(
+            self._haar_random_experiment_configuration,
+            self._bs_permanent_calculator,
+            StrategyType.CLIFFORD_R)
+        self._test_state_average_probability_for_haar_random_matrices(
+            strategy_factory)

--- a/theboss/simulation_strategies/cliffords_r_simulation_strategy.py
+++ b/theboss/simulation_strategies/cliffords_r_simulation_strategy.py
@@ -14,178 +14,155 @@ from typing import List, Dict, Tuple, DefaultDict
 
 from .simulation_strategy_interface import SimulationStrategyInterface
 
-try:
-    from rpy2 import robjects
-    from rpy2.robjects import packages
+from rpy2 import robjects
+from rpy2.robjects import packages
 
-    from ..boson_sampling_utilities.boson_sampling_utilities import \
-        particle_state_to_modes_state
+from ..boson_sampling_utilities.boson_sampling_utilities import \
+    particle_state_to_modes_state
 
 
-    class CliffordsRSimulationStrategy(SimulationStrategyInterface):
-        def __init__(self, interferometer_matrix: ndarray) -> None:
-            self.interferometer_matrix = interferometer_matrix
+class CliffordsRSimulationStrategy(SimulationStrategyInterface):
+    def __init__(self, interferometer_matrix: ndarray) -> None:
+        self.interferometer_matrix = interferometer_matrix
 
-            required_packages = ('BosonSampling', 'Rcpp', 'RcppArmadillo')
+        boson_sampling_package = packages.importr('BosonSampling')
+        self.cliffords_r_sampler = boson_sampling_package.bosonSampler
 
-            # Check if required R packages are installed. Inform if not.
-            if not all(packages.isinstalled(package) for package in required_packages):
-                print('Some packages are missing! Missing packages:')
-                for package in required_packages:
-                    if not packages.isinstalled(package):
-                        print(package)
+    def set_matrix(self, interferometer_matrix: ndarray) -> None:
+        self.interferometer_matrix = interferometer_matrix
 
-            boson_sampling_package = packages.importr('BosonSampling')
-            self.cliffords_r_sampler = boson_sampling_package.bosonSampler
+    @staticmethod
+    def _numpy_array_to_r_matrix(numpy_array: ndarray) -> robjects.r.matrix:
+        rows_number, columns_number = numpy_array.shape
+        # Transposition is required as R inserts columns, not rows.
+        r_values = robjects.ComplexVector(
+            [val for val in numpy_array.transpose().reshape(numpy_array.size)])
+        return robjects.r.matrix(r_values, nrow=rows_number, ncol=columns_number)
 
-        def set_matrix(self, interferometer_matrix: ndarray) -> None:
-            self.interferometer_matrix = interferometer_matrix
+    def simulate(self, initial_state: ndarray, samples_number: int = 1) -> List[
+        ndarray]:
+        """
+            Simulate BS experiment for given input.
 
-        @staticmethod
-        def _numpy_array_to_r_matrix(numpy_array: ndarray) -> robjects.r.matrix:
-            rows_number, columns_number = numpy_array.shape
-            # Transposition is required as R inserts columns, not rows.
-            r_values = robjects.ComplexVector(
-                [val for val in numpy_array.transpose().reshape(numpy_array.size)])
-            return robjects.r.matrix(r_values, nrow=rows_number, ncol=columns_number)
+            Note:   The results of Clifford & Clifford method are given in the first
+                    quantization description (mode assignment)!
 
-        def simulate(self, initial_state: ndarray, samples_number: int = 1) -> List[
-            ndarray]:
-            """
-                Simulate BS experiment for given input.
+            :param initial_state:   Input state in the modes occupation description.
+            :param samples_number:  Number of samples to sample.
 
-                Note:   The results of Clifford & Clifford method are given in the first
-                        quantization description (mode assignment)!
+            :return:    List of samples in the first quantization description (mode
+                        assignment)
+        """
+        number_of_bosons = int(sum(initial_state))
 
-                :param initial_state:   Input state in the modes occupation description.
-                :param samples_number:  Number of samples to sample.
+        boson_sampler_input_matrix = self._numpy_array_to_r_matrix(
+            self.interferometer_matrix[:, arange(number_of_bosons)])
 
-                :return:    List of samples in the first quantization description (mode
-                            assignment)
-            """
-            number_of_bosons = int(sum(initial_state))
+        result, permanent, probability_mass_function = \
+            self.cliffords_r_sampler(boson_sampler_input_matrix,
+                                        sampleSize=samples_number,
+                                        perm=False)
 
-            boson_sampler_input_matrix = self._numpy_array_to_r_matrix(
-                self.interferometer_matrix[:, arange(number_of_bosons)])
+        # Add -1 to R indexation of modes (they start from 1).
+        python_result = array([mode_value - 1 for mode_value in result],
+                                dtype=int64)
+        samples_in_particle_states = array_split(python_result, samples_number)
 
-            result, permanent, probability_mass_function = \
+        # There are some problems with the actual and theoretical runtimes. The
+        # reason for that could be parsing the result to a second quantization
+        # description.
+        # return samples_in_particle_states
+        samples_in_occupation_description = []
+
+        for sample in samples_in_particle_states:
+            samples_in_occupation_description.append(
+                particle_state_to_modes_state(sample, len(initial_state)))
+
+        return samples_in_occupation_description
+
+    def find_probabilities(self, initial_state: ndarray,
+                            outcomes_of_interest: List[ndarray]) \
+            -> Dict[Tuple[int, ...], float]:
+
+        number_of_bosons = int(sum(initial_state))
+
+        outcomes_of_interest = [tuple(o) for o in outcomes_of_interest]
+
+        outcomes_probabilities: dict = {}
+
+        boson_sampler_input_matrix = self._numpy_array_to_r_matrix(
+            self.interferometer_matrix[:, arange(number_of_bosons)])
+
+        number_of_samplings = 0
+
+        while len(outcomes_probabilities) != len(outcomes_of_interest):
+
+            result, permanent, pmf = \
                 self.cliffords_r_sampler(boson_sampler_input_matrix,
-                                         sampleSize=samples_number,
-                                         perm=False)
+                                            sampleSize=1,
+                                            perm=True)
+
+            number_of_samplings += 1
 
             # Add -1 to R indexation of modes (they start from 1).
             python_result = array([mode_value - 1 for mode_value in result],
-                                  dtype=int64)
-            samples_in_particle_states = array_split(python_result, samples_number)
+                                    dtype=int64)
+            sample_in_particle_states = array_split(python_result, 1)[0]
 
-            # There are some problems with the actual and theoretical runtimes. The
-            # reason for that could be parsing the result to a second quantization
-            # description.
-            # return samples_in_particle_states
-            samples_in_occupation_description = []
+            sample = tuple(particle_state_to_modes_state(sample_in_particle_states,
+                                                            len(initial_state)))
 
-            for sample in samples_in_particle_states:
-                samples_in_occupation_description.append(
-                    particle_state_to_modes_state(sample, len(initial_state)))
+            if sample in outcomes_of_interest:
+                outcomes_probabilities[sample] = pmf[0]
 
-            return samples_in_occupation_description
+            if number_of_samplings % int(1e4) == 0:
+                print(f"\tNumber of samplings: {number_of_samplings}")
 
-        def find_probabilities(self, initial_state: ndarray,
-                               outcomes_of_interest: List[ndarray]) \
-                -> Dict[Tuple[int, ...], float]:
+        return outcomes_probabilities
 
-            number_of_bosons = int(sum(initial_state))
+    def find_probabilities_of_n_random_states(self, initial_state: ndarray,
+                                                number_of_random_states: int) \
+            -> DefaultDict[Tuple[int, ...], float]:
 
-            outcomes_of_interest = [tuple(o) for o in outcomes_of_interest]
+        n = int(sum(initial_state))
+        m = len(initial_state)
 
-            outcomes_probabilities: dict = {}
+        boson_sampler_input_matrix = self._numpy_array_to_r_matrix(
+            self.interferometer_matrix[:, arange(n)])
 
-            boson_sampler_input_matrix = self._numpy_array_to_r_matrix(
-                self.interferometer_matrix[:, arange(number_of_bosons)])
+        if int(binom(n + m - 1, m - 1)) < number_of_random_states:
+            number_of_random_states = int(binom(n + m - 1, m - 1))
 
-            number_of_samplings = 0
+        probabilities_of_random_states = defaultdict(lambda: 0)
+        probabilities_sum = 0.0
+        number_of_samplings = 0
 
-            while len(outcomes_probabilities) != len(outcomes_of_interest):
+        while len(probabilities_of_random_states) < number_of_random_states or \
+                not isclose(probabilities_sum, 1):
 
-                result, permanent, pmf = \
-                    self.cliffords_r_sampler(boson_sampler_input_matrix,
-                                             sampleSize=1,
-                                             perm=True)
+            result, permanent, pmf = \
+                self.cliffords_r_sampler(boson_sampler_input_matrix,
+                                            sampleSize=1,
+                                            perm=True)
 
-                number_of_samplings += 1
+            number_of_samplings += 1
 
-                # Add -1 to R indexation of modes (they start from 1).
-                python_result = array([mode_value - 1 for mode_value in result],
-                                      dtype=int64)
-                sample_in_particle_states = array_split(python_result, 1)[0]
+            # Add -1 to R indexation of modes (they start from 1).
+            python_result = array([mode_value - 1 for mode_value in result],
+                                    dtype=int64)
+            sample_in_particle_states = array_split(python_result, 1)[0]
 
-                sample = tuple(particle_state_to_modes_state(sample_in_particle_states,
-                                                             len(initial_state)))
+            sample = tuple(particle_state_to_modes_state(sample_in_particle_states,
+                                                            len(initial_state)))
 
-                if sample in outcomes_of_interest:
-                    outcomes_probabilities[sample] = pmf[0]
+            probabilities_of_random_states[sample] = pmf[0]
 
-                if number_of_samplings % int(1e4) == 0:
-                    print(f"\tNumber of samplings: {number_of_samplings}")
+            if number_of_samplings % int(1e4) == 0:
+                print(f"\tNumber of samplings: {number_of_samplings}")
 
-            return outcomes_probabilities
-
-        def find_probabilities_of_n_random_states(self, initial_state: ndarray,
-                                                  number_of_random_states: int) \
-                -> DefaultDict[Tuple[int, ...], float]:
-
-            n = int(sum(initial_state))
-            m = len(initial_state)
-
-            boson_sampler_input_matrix = self._numpy_array_to_r_matrix(
-                self.interferometer_matrix[:, arange(n)])
-
-            if int(binom(n + m - 1, m - 1)) < number_of_random_states:
-                number_of_random_states = int(binom(n + m - 1, m - 1))
-
-            probabilities_of_random_states = defaultdict(lambda: 0)
             probabilities_sum = 0.0
-            number_of_samplings = 0
 
-            while len(probabilities_of_random_states) < number_of_random_states or \
-                 not isclose(probabilities_sum, 1):
+            for state in probabilities_of_random_states:
+                probabilities_sum += probabilities_of_random_states[state]
 
-                result, permanent, pmf = \
-                    self.cliffords_r_sampler(boson_sampler_input_matrix,
-                                             sampleSize=1,
-                                             perm=True)
-
-                number_of_samplings += 1
-
-                # Add -1 to R indexation of modes (they start from 1).
-                python_result = array([mode_value - 1 for mode_value in result],
-                                      dtype=int64)
-                sample_in_particle_states = array_split(python_result, 1)[0]
-
-                sample = tuple(particle_state_to_modes_state(sample_in_particle_states,
-                                                             len(initial_state)))
-
-                probabilities_of_random_states[sample] = pmf[0]
-
-                if number_of_samplings % int(1e4) == 0:
-                    print(f"\tNumber of samplings: {number_of_samplings}")
-
-                probabilities_sum = 0.0
-
-                for state in probabilities_of_random_states:
-                    probabilities_sum += probabilities_of_random_states[state]
-
-            return probabilities_of_random_states
-
-
-except ImportError as e:
-
-    print(f"An import error occurred during Cliffords R Strategy initialization:\n\t{e}")
-
-    class CliffordsRSimulationStrategy(SimulationStrategyInterface):
-        def __init__(self, interferometer_matrix: ndarray) -> None:
-            print("You have to install rpy2 package in order to use CliffordsRSimulationStrategy.")
-            raise NotImplementedError
-
-        def simulate(self, input_state: ndarray, samples_number: int = 1) -> List[ndarray]:
-            raise NotImplementedError
+        return probabilities_of_random_states

--- a/theboss/simulation_strategies/simulation_strategy_factory.py
+++ b/theboss/simulation_strategies/simulation_strategy_factory.py
@@ -7,7 +7,6 @@ __author__ = "Tomasz Rybotycki"
 import enum
 from copy import deepcopy
 
-from .cliffords_r_simulation_strategy import CliffordsRSimulationStrategy
 from .fixed_loss_simulation_strategy import FixedLossSimulationStrategy
 from .generalized_cliffords_simulation_strategy import GeneralizedCliffordsSimulationStrategy
 from .generalized_cliffords_uniform_losses_simulation_strategy import \
@@ -138,12 +137,35 @@ class SimulationStrategyFactory:
             self._experiment_configuration.uniform_transmissivity
         )
 
-    def _generate_r_cliffords_strategy(self) -> CliffordsRSimulationStrategy:
+    def _generate_r_cliffords_strategy(self):
         """
         Generates Cliffords algorithm strategy using their code implemented in R.
 
         :return: Cliffords strategy in R.
         """
+        try:
+            from rpy2.robjects import packages
+        except ImportError as error:
+            raise ImportError(
+                f"{str(error)}. You have to install 'rpy2' in order to use the"
+                "'CLIFFORD_R' strategy."
+            )
+
+        required_packages = ('BosonSampling', 'Rcpp', 'RcppArmadillo')
+
+        missing_packages = [
+            package
+            for package in required_packages
+            if not packages.isinstalled(package)
+        ]
+
+        if missing_packages:
+            raise ImportError(
+                f"Some R packages are missing: missing_packages='{required_packages}'"
+            )
+
+        from .cliffords_r_simulation_strategy import CliffordsRSimulationStrategy
+
         return CliffordsRSimulationStrategy(
             self._experiment_configuration.interferometer_matrix
         )

--- a/tox.ini
+++ b/tox.ini
@@ -17,13 +17,10 @@ python =
 [testenv]
 whitelist_externals = git
 # In case requirements.txt got updated, one wants to recreate (it was not automatical)
-recreate = True 
+recreate = True
 deps = -rrequirements.txt
 commands =
-	git submodule sync -q
-	git submodule update --init
-	python -m ensurepip
-    	pytest tests -s -m "not ignore"
+	pytest tests -s
 
 [tox:.package]
 basepython = python3


### PR DESCRIPTION
So far, one could not run the tests without installing R, because `rpy2`
couldn't be installed without R. By creating a separate
`optional-requirements.txt` file with a single entry `rpy2`, the
optional development dependencies are separated.

The `ignore` pytest marker is deleted, since one can use builtin
`skipif` marker. Using this, the conditional execution of
`test_haar_random_interferometers_distance_for_ccr_strategy` is written.

The `rpy2` dependency handling of `cliffords_r_simulation_strategy` is
deleted entirely, and moved to `simulation_strategy_factory`, since it
requires less boilerplate code doing this way.